### PR TITLE
FIX: Shuffle groups make_group_regression. Use `generator.choice` in make_group_classification

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -284,6 +284,7 @@ creating a release on GitHub.
 
 [ex_ci]: https://github.com/richford/groupyr/pull/8
 [ex_doc]: https://github.com/richford/groupyr/pull/10
+[ex_fix]: https://github.com/richford/groupyr/pull/16
 [ex_tst]: https://github.com/richford/groupyr/pull/11
 [link_add_commit_push]: https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line
 [link_addremote]: https://help.github.com/articles/configuring-a-remote-for-a-fork

--- a/groupyr/datasets.py
+++ b/groupyr/datasets.py
@@ -230,7 +230,7 @@ def make_group_classification(
         group_idx_map = np.concatenate(
             [
                 np.ones(n_features_per_group, dtype=np.int32) * i
-                for i in np.random.choice(
+                for i in generator.choice(
                     np.arange(n_groups), size=n_groups, replace=False
                 )
             ]
@@ -239,7 +239,7 @@ def make_group_classification(
         permute_group_map = (
             np.concatenate(
                 [
-                    np.random.choice(
+                    generator.choice(
                         np.arange(n_features_per_group),
                         size=n_features_per_group,
                         replace=False,
@@ -413,7 +413,9 @@ def make_group_regression(
         indices = np.arange(total_features)
         generator.shuffle(indices)
         X[:, :] = X[:, indices]
-        reg_coefs = reg_coefs[indices]
+        group_idx_map = group_idx_map[indices]
+        if coef:
+            reg_coefs = reg_coefs[indices]
 
     X = np.ascontiguousarray(X)
     groups = [np.where(group_idx_map == idx)[0] for idx in range(n_groups)]

--- a/groupyr/logistic.py
+++ b/groupyr/logistic.py
@@ -326,14 +326,14 @@ def logistic_sgl_path(
     if check_input:
         X = check_array(
             X,
-            accept_sparse="csc",
+            accept_sparse=False,
             dtype=[np.float64, np.float32],
             order="F",
             copy=copy_X,
         )
         y = check_array(
             y,
-            accept_sparse="csc",
+            accept_sparse=False,
             dtype=X.dtype.type,
             order="F",
             copy=False,

--- a/groupyr/tests/test_datasets.py
+++ b/groupyr/tests/test_datasets.py
@@ -146,3 +146,29 @@ def test_make_group_regression():
         n_informative_per_group=1,
     )  # n_informative=3
     assert X.shape == (100, 1)  # nosec
+
+
+@pytest.mark.parametrize(
+    "make_dataset", [make_group_classification, make_group_regression]
+)
+@pytest.mark.parametrize("shuffle", [True, False])
+def test_random_state_returns_same_data(make_dataset, shuffle):
+    X0, y0, groups0 = make_dataset(random_state=42, shuffle=shuffle)
+    X1, y1, groups1 = make_dataset(random_state=42, shuffle=shuffle)
+
+    assert_array_almost_equal(X0, X1)
+    assert_array_almost_equal(y0, y1)
+    assert_array_almost_equal(groups0, groups1)
+
+    if make_dataset == make_group_regression:
+        kwargs = {"coef": True, "shuffle": shuffle}
+    elif make_dataset == make_group_classification:
+        kwargs = {"useful_indices": True, "shuffle": shuffle}
+
+    X0, y0, groups0, coef_idx0 = make_dataset(random_state=42, **kwargs)
+    X1, y1, groups1, coef_idx1 = make_dataset(random_state=42, **kwargs)
+
+    assert_array_almost_equal(X0, X1)
+    assert_array_almost_equal(y0, y1)
+    assert_array_almost_equal(groups0, groups1)
+    assert_array_almost_equal(coef_idx0, coef_idx1)


### PR DESCRIPTION
Resolves #14 
Resolves #15 

This PR shuffles the groups in `make_group_regression`, uses `generator.choice` instead of `np.random.choice`, and adds tests to detect these bugs in the future.