### PR TITLE
MAINT: Automatically update zenodo file as part of release script

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -285,6 +285,7 @@ creating a release on GitHub.
 [ex_ci]: https://github.com/richford/groupyr/pull/8
 [ex_doc]: https://github.com/richford/groupyr/pull/10
 [ex_fix]: https://github.com/richford/groupyr/pull/16
+[ex_maint]: https://github.com/richford/groupyr/pull/17
 [ex_tst]: https://github.com/richford/groupyr/pull/11
 [link_add_commit_push]: https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line
 [link_addremote]: https://help.github.com/articles/configuring-a-remote-for-a-fork

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ target/
 
 # Mac OS files
 **.DS_Store
+
+# Line contributors file
+line-contributors.txt

--- a/.maintenance/publish_release.sh
+++ b/.maintenance/publish_release.sh
@@ -9,6 +9,7 @@ fi
 # Store version number and upstream repo name
 VERSION=$1
 REPO=$(git remote -v | grep github.com:richford/groupyr.git | head -n 1 | cut -f 1)
+BRANCH=main
 
 /bin/bash .maintenance/update_changes.sh "${VERSION}"
 
@@ -31,8 +32,20 @@ while true; do
     esac
 done
 
-git add CHANGES.rst RELEASE.rst
-git commit -m "Update CHANGES.rst and RELEASE.rst"
-git push "${REPO}" main
+/bin/bash .maintenance/update_zenodo.py
+
+echo ".zenodo.json has been automatically updated to record the line editors since the previous tag."
+while true; do
+    read -p "Would you like to review/edit .zenodo.json for this release? [y/n]" yn
+    case $yn in
+        [Yy]* ) ${EDITOR} .zenodo.json; break;;
+        [Nn]* ) break;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+git add CHANGES.rst RELEASE.rst .zenodo.json
+git commit -m "Update CHANGES.rst, RELEASE.rst, and .zenodo.json"
+git push "${REPO}" "${BRANCH}"
 git tag "${VERSION}" -F RELEASE.rst
 git push "${REPO}" "${VERSION}"

--- a/.maintenance/update_zenodo.py
+++ b/.maintenance/update_zenodo.py
@@ -15,9 +15,16 @@ from rapidfuzz import fuzz, process
 import subprocess as sp
 
 # These ORCIDs should go last
-CREATORS_LAST = ["Richie-Halford, Adam"]
+CREATORS_FIRST = ["Richie-Halford, Adam"]
+CREATORS_LAST = ["Rokem, Ariel"]
 # for entries not found in line-contributions
-MISSING_ENTRIES = []
+MISSING_ENTRIES = [
+    {
+        "affiliation": "Stanford University",
+        "name": "Narayan, Manjari",
+        "orcid": "0000-0001-5348-270X",
+    }
+]
 
 if __name__ == "__main__":
     contrib_file = Path("line-contributors.txt")
@@ -50,7 +57,7 @@ if __name__ == "__main__":
     total_names = len(zen_names) + len(MISSING_ENTRIES)
 
     name_matches = []
-    position = 1
+    position = 1 + len(CREATORS_FIRST)
     for ele in data:
         match = process.extractOne(
             ele, zen_names, scorer=fuzz.token_sort_ratio, score_cutoff=80
@@ -64,11 +71,13 @@ if __name__ == "__main__":
             continue
 
         if val not in name_matches:
-            if val["name"] not in CREATORS_LAST:
+            if val["name"] not in CREATORS_LAST and val["name"] not in CREATORS_FIRST:
                 val["position"] = position
                 position += 1
-            else:
+            elif val["name"] in CREATORS_LAST:
                 val["position"] = total_names + CREATORS_LAST.index(val["name"])
+            elif val["name"] in CREATORS_FIRST:
+                val["position"] = CREATORS_FIRST.index(val["name"])
             name_matches.append(val)
 
     for missing in MISSING_ENTRIES:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,27 +1,28 @@
 {
-  "contributors": [
-    {
-      "affiliation": "The University of Washington",
-      "name": "Rokem, Ariel",
-      "orcid": "0000-0003-0679-1985",
-      "type": "Researcher"
-    },
-    {
-      "affiliation": "Stanford University",
-      "name": "Narayan, Manjari",
-      "orcid": "0000-0001-5348-270X",
-      "type": "Researcher"
-    }
-  ],
+  "contributors": [],
   "creators": [
     {
       "affiliation": "The University of Washington",
       "name": "Richie-Halford, Adam",
       "orcid": "0000-0001-9276-9084"
+    },
+    {
+      "affiliation": "Stanford University",
+      "name": "Narayan, Manjari",
+      "orcid": "0000-0001-5348-270X"
+    },
+    {
+      "affiliation": "The University of Washington",
+      "name": "Rokem, Ariel",
+      "orcid": "0000-0003-0679-1985"
     }
   ],
   "description": "<p>groupyr is a Python library for regression and classification using the Sparse Group Lasso method.</p>",
-  "keywords": ["machine-learning", "regression", "regularization"],
+  "keywords": [
+    "machine-learning",
+    "regression",
+    "regularization"
+  ],
   "license": "BSD-3-Clause",
   "related_identifiers": [
     {

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ dev =
     sphinx==3.2.1
     sphinx-gallery==0.8.1
     sphinx-rtd-theme==0.5.0
+maint =
+    rapidfuzz==0.12.2
 
 [pydocstyle]
 convention = numpy


### PR DESCRIPTION
This PR
- updates the .zenodo.json file.
- adds the automatic zenodo update script to the publish script.
- adds a CREATORS_FIRST parameter to the automatic zenodo update script
- adds a `maint` install option which includes `rapidfuzz`. Maintainers will still have to install `git-extras` on their own.
- adds `line-contributors.txt` to `.gitignore`.