### PR TITLE
STY: Prefer `python -m pip` over `pip`. Also use taxicab random_state instead of 42

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -177,6 +177,12 @@ but those accepted fastest will follow a workflow similar to the following:
    pip install -e .[dev]
    ```
 
+   [or][link_pythonmpip_1] [better][link_pythonmpip_2] [still][link_pythonmpip_3]
+
+   ```Shell
+   python -m pip install -e .[dev]
+   ```
+
 1. **Create a [new branch][link_branches] to develop and maintain the proposed code changes.**<br />
    For example:
 
@@ -311,6 +317,9 @@ creating a release on GitHub.
 [link_np_docstring]: https://numpydoc.readthedocs.io/en/latest/format.html
 [link_pullrequest]: https://help.github.com/articles/creating-a-pull-request-from-a-fork
 [link_pushpullblog]: https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/
+[link_pythonmpip_1]: https://adamj.eu/tech/2020/02/25/use-python-m-pip-everywhere/
+[link_pythonmpip_2]: https://snarky.ca/why-you-should-use-python-m-pip/
+[link_pythonmpip_3]: https://github.com/pypa/pip/issues/3164#issue-109993120
 [link_rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
 [link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
 [link_sphinx]: http://www.sphinx-doc.org/en/master/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -292,6 +292,7 @@ creating a release on GitHub.
 [ex_doc]: https://github.com/richford/groupyr/pull/10
 [ex_fix]: https://github.com/richford/groupyr/pull/16
 [ex_maint]: https://github.com/richford/groupyr/pull/17
+[ex_sty]: https://github.com/richford/groupyr/pull/21
 [ex_tst]: https://github.com/richford/groupyr/pull/11
 [link_add_commit_push]: https://help.github.com/articles/adding-a-file-to-a-repository-using-the-command-line
 [link_addremote]: https://help.github.com/articles/configuring-a-remote-for-a-fork

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          python -m pip install .[dev]
       - name: Build docs
         run: |
           cd doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           python -m pip install --upgrade pip --use-feature=2020-resolver
           python -m pip install coveralls --use-feature=2020-resolver
           python -m pip install .[dev] --use-feature=2020-resolver
+          python -m pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
       - name: Lint
         run: |
           flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
           python -m pip install --upgrade pip --use-feature=2020-resolver
           python -m pip install coveralls --use-feature=2020-resolver
           python -m pip install .[dev] --use-feature=2020-resolver
-          pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
       - name: Lint
         run: |
           flake8

--- a/examples/plot_classifier.py
+++ b/examples/plot_classifier.py
@@ -24,7 +24,7 @@ X, y, groups, idx = make_group_classification(
     n_classes=2,
     scale=100,
     useful_indices=True,
-    random_state=42,
+    random_state=1729,
 )
 
 _, n_features = X.shape

--- a/groupyr/tests/test_datasets.py
+++ b/groupyr/tests/test_datasets.py
@@ -153,8 +153,8 @@ def test_make_group_regression():
 )
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_random_state_returns_same_data(make_dataset, shuffle):
-    X0, y0, groups0 = make_dataset(random_state=42, shuffle=shuffle)
-    X1, y1, groups1 = make_dataset(random_state=42, shuffle=shuffle)
+    X0, y0, groups0 = make_dataset(random_state=1729, shuffle=shuffle)
+    X1, y1, groups1 = make_dataset(random_state=1729, shuffle=shuffle)
 
     assert_array_almost_equal(X0, X1)
     assert_array_almost_equal(y0, y1)
@@ -165,8 +165,8 @@ def test_random_state_returns_same_data(make_dataset, shuffle):
     elif make_dataset == make_group_classification:
         kwargs = {"useful_indices": True, "shuffle": shuffle}
 
-    X0, y0, groups0, coef_idx0 = make_dataset(random_state=42, **kwargs)
-    X1, y1, groups1, coef_idx1 = make_dataset(random_state=42, **kwargs)
+    X0, y0, groups0, coef_idx0 = make_dataset(random_state=1729, **kwargs)
+    X1, y1, groups1, coef_idx1 = make_dataset(random_state=1729, **kwargs)
 
     assert_array_almost_equal(X0, X1)
     assert_array_almost_equal(y0, y1)

--- a/groupyr/tests/test_sgl.py
+++ b/groupyr/tests/test_sgl.py
@@ -147,7 +147,7 @@ def test_sgl_cv():
 
 
 @pytest.mark.parametrize("execution_number", range(5))
-@pytest.mark.parametrize("l1_ratio", np.random.default_rng(seed=42).uniform(size=4))
+@pytest.mark.parametrize("l1_ratio", np.random.default_rng(seed=1729).uniform(size=4))
 @pytest.mark.parametrize("compute_Xy", [True, "ndim2", False])
 def test_alpha_grid_starts_at_zero(execution_number, l1_ratio, compute_Xy):
     X, y, groups = make_group_regression()


### PR DESCRIPTION
This PR uses `python -m pip` over `pip` for reasons that I link to in the updated `CONTRIBUTING.md`.

It also switches all `random_state=42` to `random_state=1729`, which is the second [taxicab number](https://en.wikipedia.org/wiki/Taxicab_number).