### PR TITLE
ENH: Speed up `SparseGroupL1.prox()`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -290,6 +290,7 @@ creating a release on GitHub.
 
 [ex_ci]: https://github.com/richford/groupyr/pull/8
 [ex_doc]: https://github.com/richford/groupyr/pull/10
+[ex_enh]: https://github.com/richford/groupyr/pull/23
 [ex_fix]: https://github.com/richford/groupyr/pull/16
 [ex_maint]: https://github.com/richford/groupyr/pull/17
 [ex_sty]: https://github.com/richford/groupyr/pull/21

--- a/groupyr/logistic.py
+++ b/groupyr/logistic.py
@@ -685,7 +685,7 @@ class LogisticSGLCV(LogisticSGL):
         - an sklearn `CV splitter <https://scikit-learn.org/stable/glossary.html#term-cv-splitter>`_,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For int/None inputs, :class:`KFold` is used.
+        For int/None inputs, ``StratifiedKFold`` is used.
 
         Refer to the scikit-learn User Guide for the various
         cross-validation strategies that can be used here.

--- a/groupyr/sgl.py
+++ b/groupyr/sgl.py
@@ -594,7 +594,7 @@ class SGLCV(LinearModel, RegressorMixin, TransformerMixin):
         - an sklearn `CV splitter <https://scikit-learn.org/stable/glossary.html#term-cv-splitter>`_,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For int/None inputs, :class:`KFold` is used.
+        For int/None inputs, ``KFold`` is used.
 
         Refer to the scikit-learn User Guide for the various
         cross-validation strategies that can be used here.

--- a/groupyr/tests/test_prox.py
+++ b/groupyr/tests/test_prox.py
@@ -4,21 +4,19 @@ import pytest
 from groupyr._prox import SparseGroupL1
 
 proximal_penalties = [
-    SparseGroupL1(0.5, 1.0, groups=[np.arange(16)]),
-    SparseGroupL1(0.5, 1.0, groups=[np.arange(16)], bias_index=0),
-    SparseGroupL1(0.5, 1.0, groups=[np.arange(16)], scale_l2_by=None),
+    (SparseGroupL1(0.5, 1.0, groups=[np.arange(16)]), 16),
+    (SparseGroupL1(0.5, 1.0, groups=[np.arange(16)], scale_l2_by=None), 16),
+    (SparseGroupL1(0.5, 1.0, groups=[np.arange(16)], bias_index=16), 17),
 ]
 
 
-@pytest.mark.parametrize("penalty", proximal_penalties)
-def test_three_inequality(penalty):
+@pytest.mark.parametrize("penalty, n_features", proximal_penalties)
+def test_three_inequality(penalty, n_features):
     """Test the prox using the three point inequality
     The three-point inequality is described e.g., in Lemma 1.4
     in "Gradient-Based Algorithms with Applications to Signal
     Recovery Problems", Amir Beck and Marc Teboulle
     """
-    n_features = 16
-
     for _ in range(10):
         z = np.random.randn(n_features)
         u = np.random.randn(n_features)


### PR DESCRIPTION
This commit speeds up the SparseGroupsL1.prox() method. I ran lprun on the previous method with test data from make_group_regression. This yielded

```
Hits         Time  Per Hit   % Time  Line Contents
==================================================
1187        643.0      0.5      0.2          norms = (
2374     265686.0    111.9     80.3              np.array([np.linalg.norm(l1_prox[grp]) for grp in self.groups])
1187        940.0      0.8      0.3              / self.group_scale
                                             )
```

I realized that a lot of time could be saved by vectorizing the group norms, but also recognized the contraint that groups may be of different sizes so one can't simply use `np.linalg.norm` along one axis (since a split `l1_prox` array would be ragged). So I created a group mask matrix in ``__init__`` (since ``__init__`` is called only once but `prox` is called many times, and then used that mask and a dot product to get group norms in a much faster implementation. Running lprun on this with the same data now yields:

```
Hits         Time  Per Hit   % Time  Line Contents
==============================================================
1187      17869.0     15.1     21.1          norms = np.sqrt(self.group_masks.dot(l1_prox**2)) / self.group_scale
```

So that line, which was 80% of the execution time in`prox()`, now take 6% of the time it used to take.