### PR TITLE
Sets bayes_optimizer_ to None when "grid" strategy is used

### DIFF
--- a/groupyr/sgl.py
+++ b/groupyr/sgl.py
@@ -857,6 +857,7 @@ class SGLCV(LinearModel, RegressorMixin, TransformerMixin):
         cv = check_cv(self.cv)
 
         if self.tuning_strategy == "grid":
+            self.bayes_optimizer_ = None
             # Compute path for all folds and compute MSE to get the best alpha
             folds = list(cv.split(X, y))
             best_mse = np.inf

--- a/groupyr/tests/test_sgl.py
+++ b/groupyr/tests/test_sgl.py
@@ -162,6 +162,10 @@ def test_sgl_cv(tuning_strategy):
             tuning_strategy=tuning_strategy,
         ).fit(X, y)
         assert_array_almost_equal(clf.alphas_, clf2.alphas_)
+
+        # Make sure that this attr is set to None:
+        assert clf2.bayes_optimizer_ is None
+
     else:
         clf = SGLCV(
             l1_ratio=[0.95, 1.0],


### PR DESCRIPTION
Small (and not particularly important) follow up to #31. Just making sure that the code does what the documentation says in this case. Otherwise, this throws an `AttributeError` on access to this attribute.