### PR TITLE
FIX: Assign error_score in BayesSearchCV

### DIFF
--- a/groupyr/logistic.py
+++ b/groupyr/logistic.py
@@ -1104,6 +1104,7 @@ class LogisticSGLCV(LogisticSGL):
                 random_state=self.random_state,
                 return_train_score=True,
                 scoring=self.scoring,
+                error_score=-np.inf,
             )
 
             self.bayes_optimizer_.fit(X, y)

--- a/groupyr/sgl.py
+++ b/groupyr/sgl.py
@@ -1163,6 +1163,7 @@ class SGLCV(LinearModel, RegressorMixin, TransformerMixin):
                 random_state=self.random_state,
                 return_train_score=True,
                 scoring="neg_mean_squared_error",
+                error_score=-np.inf,
             )
 
             self.bayes_optimizer_.fit(X, y)


### PR DESCRIPTION
This PR assigns an `error_score` parameter to `BayesSearchCV` so that the optimizer doesn't fail if the estimator fails to fit.