### PR TITLE
ENH: Add lightning and group-lasso citations to paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -107,3 +107,23 @@
   doi       = {10.5281/zenodo.4014775},
   url       = {https://doi.org/10.5281/zenodo.4014775}
 }
+
+@misc{lightning-2016,
+  author = {Blondel, Mathieu and
+                  Pedregosa, Fabian},
+  title  = {{Lightning: large-scale linear classification,
+                 regression and ranking in Python}},
+  year   = 2016,
+  doi    = {10.5281/zenodo.200504},
+  url    = {https://doi.org/10.5281/zenodo.200504}
+}
+
+@misc{group-lasso,
+  author       = {Moe, Yngve Mardal},
+  title        = {Group Lasso},
+  year         = {2021},
+  publisher    = {GitHub},
+  journal      = {GitHub repository},
+  howpublished = {\url{https://github.com/yngvem/group-lasso}},
+  commit       = {5602f535c1ce79e74f7d276e73d3dec3087f11cd}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -87,14 +87,14 @@ as scikit-learn [@sklearn] [@sklearn_api] compatible estimators.
 It satisfies the need for grouped penalized regression models that
 can be used interoperably in researcher's real-world scikit-learn
 workflows. Some pre-existing Python libraries come close to satisfying
-this need. [*Lightning*](http://contrib.scikit-learn.org/lightning/)
+this need. [*Lightning*](http://contrib.scikit-learn.org/lightning/) [@lightning-2016]
 is a Python library for large-scale linear classification and
 regression. It supports many solvers with a combination of the
 L1 and L2 penalties. However, it does not allow the user to
 specify groups of covariates (see, for example, [this GitHub
 issue](https://github.com/scikit-learn-contrib/lightning/issues/39)).
 Another Python package,
-[*group_lasso*](https://group-lasso.readthedocs.io/en/latest/#), is a
+[*group_lasso*](https://group-lasso.readthedocs.io/en/latest/#) [@group-lasso], is a
 well-designed and well-documented implementation of the sparse group
 lasso. It meets the basic API requirements of scikit-learn compatible
 estimators. However, we found that our implementation in *groupyr*,


### PR DESCRIPTION
Resolves an issue brought up in [this comment](https://github.com/openjournals/joss-reviews/issues/3024#issuecomment-779410921) in the joss review thread. Thanks @janfreyberg!

There isn't really a DOI for the group-lasso reference so I kind of improvised with how to cite a GitHub repo.