### PR TITLE
DOC: Add author contributions using the CRediT taxonomy

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -72,15 +72,6 @@
   primaryclass  = {cs.LG}
 }
 
-@misc{sklearn_api,
-  title         = {{API} design for machine learning software: experiences from the scikit-learn project},
-  author        = {Lars Buitinck and Gilles Louppe and Mathieu Blondel and Fabian Pedregosa and Andreas Mueller and Olivier Grisel and Vlad Niculae and Peter Prettenhofer and Alexandre Gramfort and Jaques Grobler and Robert Layton and Jake Vanderplas and Arnaud Joly and Brian Holt and Gaël Varoquaux},
-  year          = {2013},
-  eprint        = {1309.0238},
-  archiveprefix = {arXiv},
-  primaryclass  = {cs.LG}
-}
-
 @article{sklearn,
   author  = {Pedregosa, Fabian and Varoquaux, Ga\"{e}l and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, \'{E}douard},
   title   = {Scikit-Learn: Machine Learning in {P}ython},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -121,7 +121,7 @@
   publisher    = {GitHub},
   journal      = {GitHub repository},
   howpublished = {\url{https://github.com/yngvem/group-lasso}},
-  commit       = {5602f535c1ce79e74f7d276e73d3dec3087f11cd}
+  note         = {SWHID: \href{https://archive.softwareheritage.org/swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00/}{swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00}}
 }
 
 @article{credit,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -57,16 +57,28 @@
 }
 
 @inproceedings{sklearn_api,
-  author    = {Lars Buitinck and Gilles Louppe and Mathieu Blondel and
+  author        = {Lars Buitinck and Gilles Louppe and Mathieu Blondel and
                Fabian Pedregosa and Andreas Mueller and Olivier Grisel and
                Vlad Niculae and Peter Prettenhofer and Alexandre Gramfort
                and Jaques Grobler and Robert Layton and Jake VanderPlas and
                Arnaud Joly and Brian Holt and Ga{\"{e}}l Varoquaux},
-  title     = {{API} design for machine learning software: experiences from the scikit-learn
+  title         = {{API} design for machine learning software: experiences from the scikit-learn
                project},
-  booktitle = {ECML PKDD Workshop: Languages for Data Mining and Machine Learning},
-  year      = {2013},
-  pages     = {108--122}
+  booktitle     = {ECML PKDD Workshop: Languages for Data Mining and Machine Learning},
+  year          = {2013},
+  pages         = {108--122},
+  eprint        = {1309.0238},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.LG}
+}
+
+@misc{sklearn_api,
+  title         = {{API} design for machine learning software: experiences from the scikit-learn project},
+  author        = {Lars Buitinck and Gilles Louppe and Mathieu Blondel and Fabian Pedregosa and Andreas Mueller and Olivier Grisel and Vlad Niculae and Peter Prettenhofer and Alexandre Gramfort and Jaques Grobler and Robert Layton and Jake Vanderplas and Arnaud Joly and Brian Holt and Gaël Varoquaux},
+  year          = {2013},
+  eprint        = {1309.0238},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.LG}
 }
 
 @article{sklearn,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -114,13 +114,12 @@
   url    = {https://doi.org/10.5281/zenodo.200504}
 }
 
-@software{group-lasso,
-  author     = {Moe, Yngve Mardal},
-  title      = {Group Lasso},
-  year       = {2021},
-  url        = {https://group-lasso.readthedocs.io/en/latest/#},
-  repository = {https://github.com/yngvem/group-lasso},
-  swhid      = {swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00}
+@softwareversion{group-lasso,
+  author  = {Moe, Yngve Mardal},
+  title   = {Group Lasso},
+  year    = {2020},
+  url     = {https://github.com/yngvem/group-lasso},
+  version = {\href{https://archive.softwareheritage.org/swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00;origin=https://github.com/yngvem/group-lasso;visit=swh:1:snp:f48b67a50016e1df8787bd76d9968636575a7242;anchor=swh:1:rev:0338a655cfa59ad7e97a60859702b2f30e78895e/}{swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00}}
 }
 
 @article{credit,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -114,14 +114,13 @@
   url    = {https://doi.org/10.5281/zenodo.200504}
 }
 
-@misc{group-lasso,
-  author       = {Moe, Yngve Mardal},
-  title        = {Group Lasso},
-  year         = {2021},
-  publisher    = {GitHub},
-  journal      = {GitHub repository},
-  howpublished = {\url{https://github.com/yngvem/group-lasso}},
-  note         = {SWHID: \href{https://archive.softwareheritage.org/swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00/}{swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00}}
+@software{group-lasso,
+  author     = {Moe, Yngve Mardal},
+  title      = {Group Lasso},
+  year       = {2021},
+  url        = {https://group-lasso.readthedocs.io/en/latest/#},
+  repository = {https://github.com/yngvem/group-lasso},
+  swhid      = {swh:1:dir:18ab9abeda24c3466411280c15c740ab1cbe2f00}
 }
 
 @article{credit,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -5,7 +5,7 @@
   volume  = {58},
   number  = {1},
   pages   = {267--288},
-  doi     = {https://doi.org/10.1111/j.2517-6161.1996.tb02080.x},
+  doi     = {10.1111/j.2517-6161.1996.tb02080.x},
   url     = {https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.2517-6161.1996.tb02080.x},
   year    = {1996}
 }
@@ -30,7 +30,7 @@
   volume  = {68},
   number  = {1},
   pages   = {49--67},
-  doi     = {https://doi.org/10.1111/j.1467-9868.2005.00532.x},
+  doi     = {10.1111/j.1467-9868.2005.00532.x},
   url     = {https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9868.2005.00532.x},
   year    = {2006}
 }
@@ -128,7 +128,7 @@
   volume  = {28},
   number  = {2},
   pages   = {151-155},
-  doi     = {https://doi.org/10.1087/20150211},
+  doi     = {10.1087/20150211},
   url     = {https://onlinelibrary.wiley.com/doi/abs/10.1087/20150211},
   year    = {2015}
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,34 +1,38 @@
 @article{tibshirani1996regression,
-  title     = {Regression shrinkage and selection via the lasso},
-  author    = {Tibshirani, Robert},
-  journal   = {Journal of the Royal Statistical Society: Series B (Methodological)},
-  volume    = {58},
-  number    = {1},
-  pages     = {267--288},
-  year      = {1996},
-  publisher = {Wiley Online Library}
+  author  = {Tibshirani, Robert},
+  title   = {{Regression Shrinkage and Selection Via the Lasso}},
+  journal = {Journal of the Royal Statistical Society: Series B (Methodological)},
+  volume  = {58},
+  number  = {1},
+  pages   = {267--288},
+  doi     = {https://doi.org/10.1111/j.2517-6161.1996.tb02080.x},
+  url     = {https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.2517-6161.1996.tb02080.x},
+  year    = {1996}
 }
 
 @article{simon2013sparse,
-  title     = {A sparse-group lasso},
-  author    = {Simon, Noah and Friedman, Jerome and Hastie, Trevor and Tibshirani, Robert},
-  journal   = {Journal of computational and graphical statistics},
+  author    = {Noah Simon and Jerome Friedman and Trevor Hastie and Robert Tibshirani},
+  title     = {A Sparse-Group Lasso},
+  journal   = {Journal of Computational and Graphical Statistics},
   volume    = {22},
   number    = {2},
   pages     = {231--245},
   year      = {2013},
-  publisher = {Taylor \& Francis Group}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/10618600.2012.681250},
+  url       = {https://doi.org/10.1080/10618600.2012.681250}
 }
 
 @article{yuan2006model,
-  title     = {Model selection and estimation in regression with grouped variables},
-  author    = {Yuan, Ming and Lin, Yi},
-  journal   = {Journal of the Royal Statistical Society: Series B (Statistical Methodology)},
-  volume    = {68},
-  number    = {1},
-  pages     = {49--67},
-  year      = {2006},
-  publisher = {Wiley Online Library}
+  author  = {Yuan, Ming and Lin, Yi},
+  title   = {Model selection and estimation in regression with grouped variables},
+  journal = {Journal of the Royal Statistical Society: Series B (Statistical Methodology)},
+  volume  = {68},
+  number  = {1},
+  pages   = {49--67},
+  doi     = {https://doi.org/10.1111/j.1467-9868.2005.00532.x},
+  url     = {https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9868.2005.00532.x},
+  year    = {2006}
 }
 
 @inproceedings{mosci2010solving,
@@ -66,15 +70,15 @@
 }
 
 @article{sklearn,
-  title   = {Scikit-learn: Machine Learning in {P}ython},
-  author  = {Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
-         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
-         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
-         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
-  journal = {Journal of Machine Learning Research},
+  author  = {Pedregosa, Fabian and Varoquaux, Ga\"{e}l and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, \'{E}douard},
+  title   = {Scikit-Learn: Machine Learning in {P}ython},
+  year    = {2011},
   volume  = {12},
-  pages   = {2825--2830},
-  year    = {2011}
+  issn    = {1532-4435},
+  journal = {Journal of Machine Learning Research},
+  month   = nov,
+  pages   = {2825–-2830},
+  doi     = {10.5555/1953048.2078195}
 }
 
 @article{richiehalford2019multidimensional,
@@ -100,10 +104,8 @@
 }
 
 @misc{lightning-2016,
-  author = {Blondel, Mathieu and
-                  Pedregosa, Fabian},
-  title  = {{Lightning: large-scale linear classification,
-                 regression and ranking in Python}},
+  author = {Blondel, Mathieu and Pedregosa, Fabian},
+  title  = {{Lightning: large-scale linear classification, regression and ranking in Python}},
   year   = 2016,
   doi    = {10.5281/zenodo.200504},
   url    = {https://doi.org/10.5281/zenodo.200504}
@@ -117,4 +119,16 @@
   journal      = {GitHub repository},
   howpublished = {\url{https://github.com/yngvem/group-lasso}},
   commit       = {5602f535c1ce79e74f7d276e73d3dec3087f11cd}
+}
+
+@article{credit,
+  author  = {Brand, Amy and Allen, Liz and Altman, Micah and Hlava, Marjorie and Scott, Jo},
+  title   = {Beyond authorship: attribution, contribution, collaboration, and credit},
+  journal = {Learned Publishing},
+  volume  = {28},
+  number  = {2},
+  pages   = {151-155},
+  doi     = {https://doi.org/10.1087/20150211},
+  url     = {https://onlinelibrary.wiley.com/doi/abs/10.1087/20150211},
+  year    = {2015}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -12,12 +12,12 @@ authors:
   - name: Manjari Narayan
     orcid: 0000-0001-5348-270X
     affiliation: 2
-  - name: Jason Yeatman
-    orcid: 0000-0002-2686-1293
-    affiliation: 5
   - name: Noah Simon
     orcid: 0000-0002-8985-2474
     affiliation: 4
+  - name: Jason Yeatman
+    orcid: 0000-0002-2686-1293
+    affiliation: 5
   - name: Ariel Rokem
     orcid: 0000-0003-0679-1985
     affiliation: 3
@@ -149,7 +149,23 @@ evaluations are needed to arrive at the optimal hyperparameters. We provide
 examples of both strategies (grid search for a classification example and
 SMBO for a regression example) in the online documentation.
 
-## Acknowledgments
+## Author statements and acknowledgments
+
+The first author (referred to as A.R.H. below) is the lead and corresponding
+author. The last author (referred to as A.R.) is the primary supervisor and
+is responsible for funding acquisition. All other authors are listed in
+alphabetical order by surname. We describe contributions to the paper using
+the CRediT taxonomy [@credit].
+Writing – Original Draft: A.R.H.;
+Writing – Review & Editing: A.R.H., N.S., J.Y., and A.R.;
+Conceptualization and methodology: A.R.H., N.S., and A.R.;
+Software and data curation: A.R.H., M.N., and A.R.;
+Validation: A.R.H. and M.N.;
+Resources: A.R.H. and A.R;
+Visualization: A.R.H.;
+Supervision: N.S., J.Y., and A.R.;
+Project Administration: A.R.H;
+Funding Acquisition: A.R.;
 
 Groupyr development was supported through a grant from the Gordon and
 Betty Moore Foundation and from the Alfred P. Sloan Foundation to the


### PR DESCRIPTION
This PR adds author contributions using the [CRediT taxonomy](http://dx.doi.org/10.1087/20150211).

@arokem, @mnarayan, @jyeatman, @nrs02004, please review and approve my description of the author contributions.

It also refines many of the bibtex entries for our references, adding DOIs where possible.