### PR TITLE
DOC: Add groupyr/group-lasso comparison example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,10 @@ target/
 # Line contributors file
 line-contributors.txt
 
+# Jupyter notebook files
 **.ipynb_checkpoints
 **Untitled.ipynb
+
+# PDF output
+examples/*.pdf
+paper/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ target/
 
 # Line contributors file
 line-contributors.txt
+
+**.ipynb_checkpoints
+**Untitled.ipynb

--- a/examples/compare_group_lasso_performance.py
+++ b/examples/compare_group_lasso_performance.py
@@ -1,0 +1,78 @@
+"""
+=============================================================
+Rudimentary performance comparison of groupyr and group-lasso
+=============================================================
+
+This example performs a rudimentary performance comparison of the groupyr and
+group-lasso packages for various problem sizes. Speedup is defined as the
+ratio of time to fit a `group-lasso.GroupLasso` model to the time to fit a
+`groupyr.SGL` model.
+
+In addition to `groupyr`, you will need to install the `group-lasso` package
+using
+```
+pip install group-lasso
+```
+"""
+import groupyr as gpr
+import matplotlib.pyplot as plt
+import numpy as np
+
+from group_lasso import GroupLasso
+from sklearn.model_selection import train_test_split
+from timeit import timeit
+from tqdm.auto import tqdm
+
+n_features = [5, 10, 25, 50, 75, 100, 150, 200, 250]
+speedup = []
+
+for n_features_per_group in tqdm(n_features):
+    X, y, groups, coef = gpr.datasets.make_group_regression(
+        n_samples=400,
+        n_groups=50,
+        n_informative_groups=5,
+        n_features_per_group=n_features_per_group,
+        n_informative_per_group=int(0.8 * n_features_per_group),
+        noise=200,
+        coef=True,
+        random_state=10,
+        shuffle=True,
+    )
+
+    gl_groups = np.concatenate(
+        [[idx] * len(grp) for idx, grp in enumerate(groups)]
+    ).reshape([-1, 1])
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.25, random_state=10
+    )
+
+    sgl = gpr.SGL(groups=groups, l1_ratio=0.5, alpha=1.0, max_iter=1000, tol=1e-3)
+
+    gl = GroupLasso(
+        groups=gl_groups,
+        group_reg=0.5,
+        l1_reg=0.5,
+        frobenius_lipschitz=True,
+        scale_reg="group_size",
+        n_iter=1000,
+        tol=1e-3,
+        supress_warning=True,
+    )
+
+    gpr_time = timeit("sgl.fit(X_train, y_train)", globals=globals(), number=3)
+    gl_time = timeit("gl.fit(X_train, y_train)", globals=globals(), number=3)
+
+    speedup.append(gpr_time / gl_time)
+
+fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+
+_ = ax.plot(np.array(n_features) * 50, 1 / np.array(speedup))
+_ = ax.set_xlabel(r"Number of features", fontsize=16)
+_ = ax.set_ylabel(r"$t$(group-lasso) / $t$(groupyr)", fontsize=16)
+_ = ax.set_title(
+    "\n".join([r"Rudimentary performance comparison", r"of groupyr and group-lasso"]),
+    fontsize=16,
+)
+
+fig.savefig("./groupyr_speedup.pdf", bbox_inches="tight")

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -98,7 +98,7 @@ Another Python package,
 well-designed and well-documented implementation of the sparse group lasso.
 It meets the basic API requirements of scikit-learn compatible estimators.
 However, we found that our implementation in *groupyr*, which relies on the
-*copt* optimization library [@copt], was between five and seven times faster
+*copt* optimization library [@copt], was between two and ten times faster
 for the problem sizes that we encounter in our research (see the
 repository's examples directory for a performance comparison).
 Additionally, we needed estimators with built-in cross-validation

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -95,10 +95,12 @@ specify groups of covariates (see, for example, [this GitHub
 issue](https://github.com/scikit-learn-contrib/lightning/issues/39)).
 Another Python package,
 [*group_lasso*](https://group-lasso.readthedocs.io/en/latest/#) [@group-lasso], is a
-well-designed and well-documented implementation of the sparse group
-lasso. It meets the basic API requirements of scikit-learn compatible
-estimators. However, we found that our implementation in *groupyr*,
-which relies on the *copt* optimization library [@copt], was faster.
+well-designed and well-documented implementation of the sparse group lasso.
+It meets the basic API requirements of scikit-learn compatible estimators.
+However, we found that our implementation in *groupyr*, which relies on the
+*copt* optimization library [@copt], was between five and seven times faster
+for the problem sizes that we encounter in our research (see the
+repository's examples directory for a performance comparison).
 Additionally, we needed estimators with built-in cross-validation
 support using both grid search and sequential model based optimization
 strategies. For example, the speed and cross-validation enhancements


### PR DESCRIPTION
This PR adds an example with a rudimentary performance comparison between the group-lasso package and groupyr.