### PR TITLE
ENH: Add GroupFPCA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip --use-feature=2020-resolver
           python -m pip install coveralls --use-feature=2020-resolver
-          python -m pip install .[dev] --use-feature=2020-resolver
+          python -m pip install .[dev,fda] --use-feature=2020-resolver
           python -m pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
       - name: Lint
         run: |

--- a/groupyr/decomposition.py
+++ b/groupyr/decomposition.py
@@ -2,9 +2,6 @@
 import inspect
 import numpy as np
 
-from collections import OrderedDict
-from groupyr.utils import check_groups
-
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 

--- a/groupyr/decomposition.py
+++ b/groupyr/decomposition.py
@@ -1,0 +1,204 @@
+"""Perform group-wise functional PCA of feature matrices with grouped covariates."""
+import inspect
+import numpy as np
+
+from collections import OrderedDict
+from groupyr.utils import check_groups
+
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import check_array
+
+try:
+    from skfda import FDataGrid
+    from skfda.representation.basis import Basis
+    from skfda.representation.basis import BSpline, Monomial, Constant, Fourier
+    from skfda.preprocessing.dim_reduction.projection import FPCA
+except ImportError:
+    raise ImportError(
+        "To use functional data analysis in groupyr, you will need to have "
+        "scikit-fda installed. You can do this by installing groupyr with "
+        "`pip install groupyr[fda]`, or by separately installing scikit-fda "
+        "with `pip install scikit-fda`."
+    )
+
+from .utils import check_groups
+
+
+def _has_nbasis_kwarg(_basis):
+    try:
+        # Not all bases have an ``n_basis`` kwarg
+        # If we just tried to instantiate the basis, then
+        # we'd catch all TypeErrors raised by ``basis``.
+        # Instead, we use ``inspect``
+        inspect.signature(_basis).bind(n_basis=7)
+        return True
+    except TypeError:
+        return False
+
+
+def _check_basis(basis, arg_name, n_basis):
+    allowed_bases = {
+        "bspline": BSpline,
+        "monomial": Monomial,
+        "constant": Constant,
+        "fourier": Fourier,
+    }
+
+    err_msg = (
+        f"{arg_name} must be one of {list(allowed_bases.keys())} or be an "
+        f"instance of a basis class from `skfda.representation.basis`."
+    )
+
+    if inspect.isclass(basis):
+        if not issubclass(basis, Basis):
+            raise ValueError(err_msg)
+
+        if _has_nbasis_kwarg(basis):
+            return basis(n_basis=n_basis)
+        else:
+            return basis()
+    elif basis is not None:
+        if basis.lower() not in allowed_bases.keys():
+            raise ValueError(err_msg)
+
+        if _has_nbasis_kwarg(allowed_bases[basis.lower()]):
+            return allowed_bases[basis.lower()](n_basis=n_basis)
+        else:
+            return allowed_bases[basis.lower()]()
+
+    return None
+
+
+def _get_group_fd(X, group_mask, basis):
+    group_X = np.copy(X[:, group_mask])
+    fd = FDataGrid(group_X, np.arange(0, group_X.shape[1]))
+    if basis is not None:
+        fd = fd.to_basis(basis)
+    return fd
+
+
+class GroupFPCA(BaseEstimator, TransformerMixin):
+    """An sklearn-compatible grouped functional PCA transformer.
+
+    Given a feature matrix `X` and grouping information,
+    this transformer returns the groupwise functional PCA
+    matrix.
+
+    Parameters
+    ----------
+    n_components : int, default=3
+        number of principal components to obtain from functional
+        principal component analysis.
+
+    basis : str, instance of `skfda.representation.basis` class, optional
+        the basis in which to represent each group's function before fPCA.
+
+    n_basis : int, default=4
+        the number of functions in the basis. Only used if ``basis`` is not
+        None.
+
+    groups : numpy.ndarray or int, optional
+        all group indices for feature matrix
+
+    exclude_groups : sequence of int or int, optional
+        a sequence of group indices (or a single group index) to exclude from
+        fPCA transformatiton. These groups will be left untouched and
+        transferred to the output matrix.
+    """
+
+    def __init__(
+        self, n_components=3, basis=None, n_basis=4, groups=None, exclude_groups=None
+    ):
+        self.n_components = n_components
+        self.basis = basis
+        self.n_basis = n_basis
+        self.groups = groups
+        self.exclude_groups = exclude_groups
+
+    def transform(self, X, y=None):
+        """Transform the input data.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            The feature matrix
+        """
+        X = check_array(
+            X, copy=True, dtype=[np.float32, np.float64, int], force_all_finite=True
+        )
+        basis = _check_basis(self.basis, "basis", self.n_basis)
+        groups = check_groups(groups=self.groups_, X=X, allow_overlap=True)
+
+        X_out = []
+        for idx, grp in enumerate(groups):
+            if self.fpca_models_[idx] is not None:
+                fd = _get_group_fd(X, grp, basis)
+                X_out.append(self.fpca_models_[idx].transform(fd))
+            else:
+                X_out.append(X[:, grp])
+
+        return np.hstack(X_out)
+
+    def fit(self, X=None, y=None):
+        """Fit the fPCA transformer.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            The feature matrix
+        """
+        X = check_array(
+            X, copy=True, dtype=[np.float32, np.float64, int], force_all_finite=True
+        )
+        basis = _check_basis(self.basis, "basis", self.n_basis)
+
+        _, self.n_features_in_ = X.shape
+        self.groups_ = check_groups(groups=self.groups, X=X, allow_overlap=True)
+
+        if self.exclude_groups is None:
+            exclude_grp_idx = []
+        elif isinstance(self.exclude_groups, int):
+            exclude_grp_idx = [self.exclude_groups]
+        elif all(isinstance(e, int) for e in self.exclude_groups):
+            exclude_grp_idx = list(self.exclude_groups)
+        else:
+            raise TypeError(
+                f"exclude_groups must be and int or sequence of ints. "
+                f"Got {self.exclude_groups} instead."
+            )
+
+        self.fpca_models_ = [
+            FPCA(n_components=self.n_components) for grp in self.groups_
+        ]
+        self.components_ = [None for grp in self.groups_]
+        self.groups_out_ = []
+
+        feature_start_idx = 0
+        for idx, grp in enumerate(self.groups_):
+            if idx not in exclude_grp_idx:
+                fd = _get_group_fd(X, grp, basis)
+                self.fpca_models_[idx].fit(fd)
+                self.components_[idx] = self.fpca_models_[idx].components_
+                self.groups_out_.append(
+                    np.arange(feature_start_idx, feature_start_idx + self.n_components)
+                )
+                feature_start_idx += self.n_components
+            else:
+                self.fpca_models_[idx] = None
+                # self.components_ is already set to None above
+                self.groups_out_.append(
+                    np.arange(feature_start_idx, feature_start_idx + len(grp))
+                )
+                feature_start_idx += len(grp)
+
+        self.n_features_out_ = np.sum([len(grp) for grp in self.groups_out_])
+
+        return self
+
+    def _more_tags(self):  # pylint: disable=no-self-use
+        return {
+            "allow_nan": False,
+            "multilabel": True,
+            "multioutput": True,
+            "_skip_test": True,
+        }

--- a/groupyr/decomposition.py
+++ b/groupyr/decomposition.py
@@ -87,6 +87,10 @@ class GroupFPCA(BaseEstimator, TransformerMixin):
         number of principal components to obtain from functional
         principal component analysis.
 
+    centering : bool, default=True
+        if True then calculate the mean of the functional data object and
+        center the data first.
+
     basis : str, instance of `skfda.representation.basis` class, optional
         the basis in which to represent each group's function before fPCA.
 
@@ -104,9 +108,16 @@ class GroupFPCA(BaseEstimator, TransformerMixin):
     """
 
     def __init__(
-        self, n_components=3, basis=None, n_basis=4, groups=None, exclude_groups=None
+        self,
+        n_components=3,
+        centering=True,
+        basis=None,
+        n_basis=4,
+        groups=None,
+        exclude_groups=None,
     ):
         self.n_components = n_components
+        self.centering = centering
         self.basis = basis
         self.n_basis = n_basis
         self.groups = groups
@@ -165,7 +176,8 @@ class GroupFPCA(BaseEstimator, TransformerMixin):
             )
 
         self.fpca_models_ = [
-            FPCA(n_components=self.n_components) for grp in self.groups_
+            FPCA(n_components=self.n_components, centering=self.centering)
+            for grp in self.groups_
         ]
         self.components_ = [None for grp in self.groups_]
         self.groups_out_ = []

--- a/groupyr/tests/test_common.py
+++ b/groupyr/tests/test_common.py
@@ -4,7 +4,6 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from groupyr._base import SGLBaseEstimator
 from groupyr import LogisticSGL, LogisticSGLCV, SGL, SGLCV
-from groupyr.decomposition import GroupFPCA
 
 
 @pytest.mark.parametrize("Estimator", [SGLBaseEstimator, SGL, LogisticSGL])

--- a/groupyr/tests/test_common.py
+++ b/groupyr/tests/test_common.py
@@ -4,6 +4,7 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from groupyr._base import SGLBaseEstimator
 from groupyr import LogisticSGL, LogisticSGLCV, SGL, SGLCV
+from groupyr.decomposition import GroupFPCA
 
 
 @pytest.mark.parametrize("Estimator", [SGLBaseEstimator, SGL, LogisticSGL])

--- a/groupyr/tests/test_decomposition.py
+++ b/groupyr/tests/test_decomposition.py
@@ -1,0 +1,146 @@
+import numpy as np
+import pytest
+
+from groupyr.decomposition import GroupFPCA
+from skfda import FDataGrid
+from skfda.datasets import fetch_weather
+from skfda.representation.basis import BSpline, Constant, Fourier
+from sklearn.utils.estimator_checks import check_estimator
+
+
+def test_group_fpca_matches_skfda_results():
+    n_basis = 9
+    n_components = 3
+
+    grid_points = np.arange(0.5, 365, 1)
+    fd_data = fetch_weather()["data"].coordinates[0]
+    fd_data = FDataGrid(np.squeeze(fd_data.data_matrix), grid_points)
+    X = fd_data.data_matrix.squeeze()
+    X = np.hstack([X, X])
+    groups = [np.arange(0, 365), np.arange(365, 730)]
+    gfpca = GroupFPCA(
+        n_components=n_components,
+        n_basis=n_basis,
+        basis_domain_range=(0, 365),
+        basis="Fourier",
+        groups=groups,
+    )
+
+    _ = gfpca.fit_transform(X, grid_points=np.hstack([grid_points, grid_points]))
+
+    results = [
+        [
+            0.9231551,
+            0.1364966,
+            0.3569451,
+            0.0092012,
+            -0.0244525,
+            -0.02923873,
+            -0.003566887,
+            -0.009654571,
+            -0.0100063,
+        ],
+        [
+            -0.3315211,
+            -0.0508643,
+            0.89218521,
+            0.1669182,
+            0.2453900,
+            0.03548997,
+            0.037938051,
+            -0.025777507,
+            0.008416904,
+        ],
+        [
+            -0.1379108,
+            0.9125089,
+            0.00142045,
+            0.2657423,
+            -0.2146497,
+            0.16833314,
+            0.031509179,
+            -0.006768189,
+            0.047306718,
+        ],
+    ]
+    results = np.array(results)
+
+    for grp_idx in range(len(groups)):
+        # The sign of the components is arbitrary so we change the sign if necessary
+        for i in range(n_components):
+            if np.sign(gfpca.components_[grp_idx].coefficients[i][0]) != np.sign(
+                results[i][0]
+            ):
+                results[i, :] *= -1
+
+        np.testing.assert_allclose(
+            gfpca.components_[grp_idx].coefficients, results, atol=1e-7
+        )
+
+
+@pytest.mark.parametrize(
+    "basis", ["constant", "bspline", None, BSpline, Constant, Fourier]
+)
+@pytest.mark.parametrize("use_grid_points", [True, False])
+@pytest.mark.parametrize("exclude_groups", [None, 1, [1]])
+def test_group_fpca_bases(basis, use_grid_points, exclude_groups):
+    n_basis = 9
+    n_components = 1
+
+    grid_points = np.arange(0.5, 365, 1)
+    fd_data = fetch_weather()["data"].coordinates[0]
+    fd_data = FDataGrid(np.squeeze(fd_data.data_matrix), grid_points)
+    X = fd_data.data_matrix.squeeze()
+    X = np.hstack([X, X])
+    groups = [np.arange(0, 365), np.arange(365, 730)]
+
+    if use_grid_points:
+        grid_points = np.hstack([grid_points, grid_points])
+    else:
+        grid_points = None
+
+    gfpca = GroupFPCA(
+        n_components=n_components,
+        n_basis=n_basis,
+        basis_domain_range=(0, 365),
+        basis=basis,
+        groups=groups,
+        exclude_groups=exclude_groups,
+    ).fit(X, grid_points=grid_points)
+
+    _ = gfpca.transform(X, grid_points=grid_points)
+
+
+def test_groupfpca_errors():
+    n_basis = 9
+    n_components = 1
+
+    grid_points = np.arange(0.5, 365, 1)
+    fd_data = fetch_weather()["data"].coordinates[0]
+    fd_data = FDataGrid(np.squeeze(fd_data.data_matrix), grid_points)
+    X = fd_data.data_matrix.squeeze()
+    X = np.hstack([X, X])
+    groups = [np.arange(0, 365), np.arange(365, 730)]
+
+    with pytest.raises(ValueError):
+        GroupFPCA(
+            n_components=n_components, n_basis=n_basis, basis=object, groups=groups
+        ).fit(X)
+
+    with pytest.raises(ValueError):
+        GroupFPCA(
+            n_components=n_components, n_basis=n_basis, basis="error", groups=groups
+        ).fit(X)
+
+    with pytest.raises(TypeError):
+        GroupFPCA(
+            n_components=n_components,
+            n_basis=n_basis,
+            groups=groups,
+            exclude_groups="error",
+        ).fit(X)
+
+
+@pytest.mark.parametrize("Transformer", [GroupFPCA])
+def test_all_estimators(Transformer):
+    return check_estimator(Transformer())

--- a/groupyr/utils.py
+++ b/groupyr/utils.py
@@ -2,11 +2,11 @@
 import numpy as np
 
 
-def check_groups(groups, X, allow_overlap=False, fit_intercept=False):
+def check_groups(groups, X, allow_overlap=False, fit_intercept=False, kwarg_name="X"):
     """Validate group indices.
 
     Verify that all features in ``X`` are accounted for in groups,
-    that all groups refer to features that actually exist in ``XX``,
+    that all groups refer to features that actually exist in ``X``,
     and, if ``allow_overlap=False``, that all groups are distinct.
 
     Parameters
@@ -32,12 +32,17 @@ def check_groups(groups, X, allow_overlap=False, fit_intercept=False):
         If True, assume that the last column of the feature matrix
         corresponds to the bias or intercept.
 
+    kwarg_name : str, default="X"
+        The keyword argument name used to customize error messages. Defaults to
+        "X" as this function is most commonly used to check feature matrices
+        during fit, transform, and predict functions.
+
     Returns
     -------
     groups : list of numpy.ndarray
         The validated groups.
     """
-    _, n_features = X.shape
+    n_features = X.shape[-1]
 
     if fit_intercept:
         n_features -= 1
@@ -59,8 +64,8 @@ def check_groups(groups, X, allow_overlap=False, fit_intercept=False):
     if set(all_indices) > set(range(n_features)):
         raise ValueError(
             "There are feature indices in groups that exceed the dimensions "
-            "of X; X has {0} features but groups refers to indices {1}".format(
-                n_features, set(all_indices) - set(range(n_features))
+            "of {0}; {0} has {1} features but groups refers to indices {2}".format(
+                kwarg_name, n_features, set(all_indices) - set(range(n_features))
             )
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ dev =
     tox>=1.8.0
 maint =
     rapidfuzz==0.12.2
+fda =
+    scikit-fda>=0.5
 
 [pydocstyle]
 convention = numpy

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     scipy>=1.2.0,<1.6.0
     copt==0.8.4
     scikit-optimize>=0.8.1
+    scikit-fda>=0.5
     tqdm>=4.0.0
     sklearn231: scikit-learn==0.23.1
     sklearn232: scikit-learn==0.23.2


### PR DESCRIPTION
This PR adds a group-wise functional FPCA transformer. It computes functional PCA for each group (excluding the groups specified by the user on init) during `fit`. And then transforms into the lower dimensional PC space during `transform`.

It is a WIP because I haven't added tests.