### PR TITLE
ENH: Add group transformers

### DIFF
--- a/groupyr/tests/test_transform.py
+++ b/groupyr/tests/test_transform.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
 
-from groupyr.transform import isiterable, GroupExtractor, GroupRemover
+from groupyr.transform import isiterable, GroupExtractor
+from groupyr.transform import GroupRemover, GroupShuffler
 from sklearn.utils.estimator_checks import check_estimator
+from sklearn.utils import shuffle as util_shuffle
 
 
 def test_isiterable():
@@ -27,47 +29,47 @@ def test_GroupExtractor():
         ("three", "beta"),
     ]
 
-    extract = 2
-    ge = GroupExtractor(groups=groups, extract=extract)
+    select = 2
+    ge = GroupExtractor(groups=groups, select=select)
     X_tr = ge.fit_transform(X)
-    assert np.allclose(X[:, groups[extract]], X_tr)  # nosec
+    assert np.allclose(X[:, groups[select]], X_tr)  # nosec
 
-    extract = "two"
-    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t == extract])
-    ge = GroupExtractor(groups=groups, group_names=group_names, extract=extract)
-    X_tr = ge.fit_transform(X)
-    assert np.allclose(X[:, idx], X_tr)  # nosec
-
-    extract = ["two", "three"]
-    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t in extract])
-    ge = GroupExtractor(groups=groups, group_names=group_names, extract=extract)
+    select = "two"
+    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t == select])
+    ge = GroupExtractor(groups=groups, group_names=group_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    extract = "one"
+    select = ["two", "three"]
+    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t in select])
+    ge = GroupExtractor(groups=groups, group_names=group_names, select=select)
+    X_tr = ge.fit_transform(X)
+    assert np.allclose(X[:, idx], X_tr)  # nosec
+
+    select = "one"
     idx = np.concatenate(
-        [grp for grp, t in zip(groups, group_tuple_names) if t[0] == extract]
+        [grp for grp, t in zip(groups, group_tuple_names) if t[0] == select]
     )
-    ge = GroupExtractor(groups=groups, group_names=group_tuple_names, extract=extract)
+    ge = GroupExtractor(groups=groups, group_names=group_tuple_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    extract = ["alpha", "three"]
+    select = ["alpha", "three"]
     idx = np.concatenate(
         [
             grp
             for grp, t in zip(groups, group_tuple_names)
-            if any([r in t for r in extract])
+            if any([r in t for r in select])
         ]
     )
-    ge = GroupExtractor(groups=groups, group_names=group_tuple_names, extract=extract)
+    ge = GroupExtractor(groups=groups, group_names=group_tuple_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    extract = [0, 3]
-    ge = GroupExtractor(groups=groups, extract=extract)
+    select = [0, 3]
+    ge = GroupExtractor(groups=groups, select=select)
     X_tr = ge.fit_transform(X)
-    idx = np.concatenate([groups[e] for e in extract])
+    idx = np.concatenate([groups[e] for e in select])
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
     ge = GroupExtractor()
@@ -75,7 +77,7 @@ def test_GroupExtractor():
     assert np.allclose(X_tr, X)  # nosec
 
     with pytest.raises(ValueError):
-        GroupExtractor(extract="error").fit_transform(X)
+        GroupExtractor(select="error").fit_transform(X)
 
 
 def test_GroupRemover():
@@ -94,50 +96,50 @@ def test_GroupRemover():
         ("three", "beta"),
     ]
 
-    remove = 2
-    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx != remove])
-    ge = GroupRemover(groups=groups, remove=remove)
+    select = 2
+    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx != select])
+    ge = GroupRemover(groups=groups, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    remove = "two"
-    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t != remove])
-    ge = GroupRemover(groups=groups, group_names=group_names, remove=remove)
+    select = "two"
+    idx = np.concatenate([grp for grp, t in zip(groups, group_names) if t != select])
+    ge = GroupRemover(groups=groups, group_names=group_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    remove = ["two", "three"]
+    select = ["two", "three"]
     idx = np.concatenate(
-        [grp for grp, t in zip(groups, group_names) if t not in remove]
+        [grp for grp, t in zip(groups, group_names) if t not in select]
     )
-    ge = GroupRemover(groups=groups, group_names=group_names, remove=remove)
+    ge = GroupRemover(groups=groups, group_names=group_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    remove = "one"
+    select = "one"
     idx = np.concatenate(
-        [grp for grp, t in zip(groups, group_tuple_names) if t[0] != remove]
+        [grp for grp, t in zip(groups, group_tuple_names) if t[0] != select]
     )
-    ge = GroupRemover(groups=groups, group_names=group_tuple_names, remove=remove)
+    ge = GroupRemover(groups=groups, group_names=group_tuple_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    remove = ["alpha", "three"]
+    select = ["alpha", "three"]
     idx = np.concatenate(
         [
             grp
             for grp, t in zip(groups, group_tuple_names)
-            if all([r not in t for r in remove])
+            if all([r not in t for r in select])
         ]
     )
-    ge = GroupRemover(groups=groups, group_names=group_tuple_names, remove=remove)
+    ge = GroupRemover(groups=groups, group_names=group_tuple_names, select=select)
     X_tr = ge.fit_transform(X)
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
-    remove = [0, 3]
-    ge = GroupRemover(groups=groups, remove=remove)
+    select = [0, 3]
+    ge = GroupRemover(groups=groups, select=select)
     X_tr = ge.fit_transform(X)
-    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx not in remove])
+    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx not in select])
     assert np.allclose(X[:, idx], X_tr)  # nosec
 
     ge = GroupRemover()
@@ -145,7 +147,7 @@ def test_GroupRemover():
     assert np.allclose(X_tr, X)  # nosec
 
     with pytest.raises(ValueError):
-        GroupRemover(remove=object()).fit_transform(X)
+        GroupRemover(select=object()).fit_transform(X)
 
     with pytest.raises(ValueError):
         GroupRemover(group_names=group_names).fit_transform(X)
@@ -154,15 +156,105 @@ def test_GroupRemover():
         GroupRemover(groups=groups, group_names=["a", "b"]).fit_transform(X)
 
     with pytest.raises(ValueError):
-        GroupRemover(groups=groups, remove="b").fit_transform(X)
+        GroupRemover(groups=groups, select="b").fit_transform(X)
 
     with pytest.raises(ValueError):
-        GroupRemover(groups=groups, remove=["a", "b"]).fit_transform(X)
+        GroupRemover(groups=groups, select=["a", "b"]).fit_transform(X)
 
     with pytest.raises(TypeError):
         GroupRemover(groups=groups, group_names=0).fit_transform(X)
 
 
-@pytest.mark.parametrize("Transformer", [GroupExtractor, GroupRemover])
+def assert_shuffle_match(
+    X, X_tr, groups=None, group_names=None, select=None, random_state=0
+):
+    ge = GroupExtractor(select=select, groups=groups, group_names=group_names)
+    shuffled = {"orig": ge.fit_transform(X), "tran": ge.fit_transform(X_tr)}
+    gr = GroupRemover(select=select, groups=groups, group_names=group_names)
+    same = {"orig": gr.fit_transform(X), "tran": gr.fit_transform(X_tr)}
+    assert np.allclose(same["orig"], same["tran"])
+    assert np.allclose(
+        util_shuffle(shuffled["orig"], random_state=random_state), shuffled["tran"]
+    )
+
+
+def test_GroupShuffler():
+    X = np.arange(100).reshape(10, 10)
+    groups = [
+        np.array([0, 1, 2]),
+        np.array([3, 4, 5]),
+        np.array([6, 7, 8]),
+        np.array([9]),
+    ]
+    group_names = ["one", "two", "three", "four"]
+    group_tuple_names = [
+        ("one", "alpha"),
+        ("one", "beta"),
+        ("two", "alpha"),
+        ("three", "beta"),
+    ]
+
+    select = 2
+    gs = GroupShuffler(groups=groups, select=select, random_state=0)
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(X, X_tr, groups=groups, select=select, random_state=0)
+
+    select = "two"
+    gs = GroupShuffler(
+        groups=groups, group_names=group_names, select=select, random_state=0
+    )
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(
+        X, X_tr, groups=groups, group_names=group_names, select=select, random_state=0
+    )
+
+    select = ["two", "three"]
+    gs = GroupShuffler(
+        groups=groups, group_names=group_names, select=select, random_state=0
+    )
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(
+        X, X_tr, groups=groups, group_names=group_names, select=select, random_state=0
+    )
+
+    select = "one"
+    gs = GroupShuffler(
+        groups=groups, group_names=group_tuple_names, select=select, random_state=0
+    )
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(
+        X,
+        X_tr,
+        groups=groups,
+        group_names=group_tuple_names,
+        select=select,
+        random_state=0,
+    )
+
+    select = ["alpha", "three"]
+    gs = GroupShuffler(
+        groups=groups, group_names=group_tuple_names, select=select, random_state=0
+    )
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(
+        X,
+        X_tr,
+        groups=groups,
+        group_names=group_tuple_names,
+        select=select,
+        random_state=0,
+    )
+
+    select = [0, 3]
+    gs = GroupShuffler(groups=groups, select=select, random_state=0)
+    X_tr = gs.fit_transform(X)
+    assert_shuffle_match(X, X_tr, groups=groups, select=select, random_state=0)
+
+    gs = GroupShuffler()
+    X_tr = gs.fit_transform(X)
+    assert np.allclose(X_tr, X)  # nosec
+
+
+@pytest.mark.parametrize("Transformer", [GroupExtractor, GroupRemover, GroupShuffler])
 def test_all_estimators(Transformer):
     return check_estimator(Transformer())

--- a/groupyr/tests/test_transform.py
+++ b/groupyr/tests/test_transform.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+from groupyr.transform import isiterable, GroupExtractor, GroupRemover
+from sklearn.utils.estimator_checks import check_estimator
+
+
+def test_isiterable():
+    assert isiterable(range(10))  # nosec
+    assert not isiterable(5)  # nosec
+    assert isiterable(np.arange(10))  # nosec
+
+
+def test_GroupExtractor():
+    X = np.array([list(range(10))] * 10)
+    groups = [
+        np.array([0, 1, 2]),
+        np.array([3, 4, 5]),
+        np.array([6, 7, 8]),
+        np.array([9]),
+    ]
+
+    extract = 2
+    ge = GroupExtractor(groups=groups, extract=extract)
+    X_tr = ge.fit_transform(X)
+    assert np.allclose(X[:, groups[extract]], X_tr)  # nosec
+
+    extract = [0, 3]
+    ge = GroupExtractor(groups=groups, extract=extract)
+    X_tr = ge.fit_transform(X)
+    idx = np.concatenate([groups[e] for e in extract])
+    assert np.allclose(X[:, idx], X_tr)  # nosec
+
+    ge = GroupExtractor()
+    X_tr = ge.fit_transform(X)
+    assert np.allclose(X_tr, X)  # nosec
+
+    with pytest.raises(ValueError):
+        GroupExtractor(extract="error").fit_transform(X)
+
+
+def test_GroupRemover():
+    X = np.array([list(range(10))] * 10)
+    groups = [
+        np.array([0, 1, 2]),
+        np.array([3, 4, 5]),
+        np.array([6, 7, 8]),
+        np.array([9]),
+    ]
+
+    remove = 2
+    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx != remove])
+    ge = GroupRemover(groups=groups, remove=remove)
+    X_tr = ge.fit_transform(X)
+    assert np.allclose(X[:, idx], X_tr)  # nosec
+
+    remove = [0, 3]
+    ge = GroupRemover(groups=groups, remove=remove)
+    X_tr = ge.fit_transform(X)
+    idx = np.concatenate([grp for idx, grp in enumerate(groups) if idx not in remove])
+    assert np.allclose(X[:, idx], X_tr)  # nosec
+
+    ge = GroupRemover()
+    X_tr = ge.fit_transform(X)
+    assert np.allclose(X_tr, X)  # nosec
+
+    with pytest.raises(ValueError):
+        GroupRemover(remove="error").fit_transform(X)
+
+
+@pytest.mark.parametrize("Transformer", [GroupExtractor, GroupRemover])
+def test_all_estimators(Transformer):
+    return check_estimator(Transformer())

--- a/groupyr/transform.py
+++ b/groupyr/transform.py
@@ -1,0 +1,171 @@
+"""Transform feature matrices with grouped covariates."""
+import numpy as np
+
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import check_array
+
+from .utils import check_groups
+
+
+def isiterable(obj):
+    """Return True if obj is an iterable, False otherwise."""
+    try:
+        _ = iter(obj)  # noqa F841
+    except TypeError:
+        return False
+    else:
+        return True
+
+
+class GroupExtractor(BaseEstimator, TransformerMixin):
+    """An sklearn-compatible group extractor.
+
+    Given a sequence of all group indices and a subsequence of desired
+    group indices, this transformer returns the columns of the feature
+    matrix, `X`, that are in the desired subgroups.
+
+    Parameters
+    ----------
+    extract : numpy.ndarray or int, optional
+        subsequence of desired groups to extract from feature matrix
+
+    groups : list of numpy.ndarray
+        list of arrays of non-overlapping indices for each group. For
+        example, if nine features are grouped into equal contiguous groups of
+        three, then groups would be ``[array([0, 1, 2]), array([3, 4, 5]),
+        array([6, 7, 8])]``. If the feature matrix contains a bias or
+        intercept feature, do not include it as a group. If None, all
+        features will belong to one group.
+
+    copy_X : bool, default=False
+        if ``True``, X will be copied; else, ``transform`` may return a view
+    """
+
+    def __init__(self, extract=None, groups=None, copy_X=False):
+        self.extract = extract
+        self.groups = groups
+        self.copy_X = copy_X
+
+    def transform(self, X, y=None):
+        """Transform the input data, extracting the desired groups.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            The feature matrix
+        """
+        X = check_array(
+            X,
+            copy=self.copy_X,
+            dtype=[np.float32, np.float64, int],
+            force_all_finite=False,
+        )
+        groups = check_groups(groups=self.groups_, X=X, allow_overlap=True)
+        if self.extract is None:
+            return X
+        elif isiterable(self.extract) and all(isinstance(e, int) for e in self.extract):
+            extract = np.array(self.extract)
+        elif isinstance(self.extract, int):
+            extract = np.array([self.extract])
+        else:
+            raise ValueError(
+                "extract must be an int or sequence of ints; got "
+                "{0} instead".format(self.extract)
+            )
+
+        idx = np.concatenate([groups[e] for e in extract])
+        return X[:, idx]
+
+    def fit(self, X=None, y=None):
+        """Learn the groups and number of features from the input data."""
+        X = check_array(
+            X,
+            copy=self.copy_X,
+            dtype=[np.float32, np.float64, int],
+            force_all_finite=False,
+        )
+
+        _, self.n_features_in_ = X.shape
+        self.groups_ = check_groups(groups=self.groups, X=X, allow_overlap=True)
+        return self
+
+    def _more_tags(self):  # pylint: disable=no-self-use
+        return {"allow_nan": True, "multilabel": True, "multioutput": True}
+
+
+class GroupRemover(BaseEstimator, TransformerMixin):
+    """An sklearn-compatible group remover.
+
+    Given a sequence of all group indices and a subsequence of unwanted
+    group indices, this transformer returns the columns of the feature
+    matrix, `X`, that DO NOT include the unwanted subgroups.
+
+    Parameters
+    ----------
+    remove : numpy.ndarray or int, optional
+        subsequence of desired groups to remove from feature matrix
+
+    groups : list of numpy.ndarray
+        list of arrays of non-overlapping indices for each group. For
+        example, if nine features are grouped into equal contiguous groups of
+        three, then groups would be ``[array([0, 1, 2]), array([3, 4, 5]),
+        array([6, 7, 8])]``. If the feature matrix contains a bias or
+        intercept feature, do not include it as a group. If None, all
+        features will belong to one group.
+
+    copy_X : bool, default=False
+        if ``True``, X will be copied; else, ``transform`` may return a view
+    """
+
+    def __init__(self, remove=None, groups=None, copy_X=False):
+        self.remove = remove
+        self.groups = groups
+        self.copy_X = copy_X
+
+    def transform(self, X, y=None):
+        """Transform the input data, removing the unwanted groups.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            The feature matrix
+        """
+        X = check_array(
+            X,
+            copy=self.copy_X,
+            dtype=[np.float32, np.float64, int],
+            force_all_finite=False,
+        )
+        groups = check_groups(groups=self.groups_, X=X, allow_overlap=True)
+        if self.remove is None:
+            return X
+        elif isiterable(self.remove) and all(isinstance(e, int) for e in self.remove):
+            remove = np.array(self.remove)
+        elif isinstance(self.remove, int):
+            remove = np.array([self.remove])
+        else:
+            raise ValueError(
+                "remove must be an int or sequence of ints; got "
+                "{0} instead".format(self.remove)
+            )
+
+        idx = np.concatenate(
+            [grp for idx, grp in enumerate(groups) if idx not in remove]
+        )
+        return X[:, idx]
+
+    def fit(self, X=None, y=None):
+        """Learn the groups and number of features from the input data."""
+        X = check_array(
+            X,
+            copy=self.copy_X,
+            dtype=[np.float32, np.float64, int],
+            force_all_finite=False,
+        )
+
+        _, self.n_features_in_ = X.shape
+        self.groups_ = check_groups(groups=self.groups, X=X, allow_overlap=True)
+        return self
+
+    def _more_tags(self):  # pylint: disable=no-self-use
+        return {"allow_nan": True, "multilabel": True, "multioutput": True}

--- a/groupyr/transform.py
+++ b/groupyr/transform.py
@@ -17,6 +17,61 @@ def isiterable(obj):
         return True
 
 
+def _check_group_names(groups, group_names):
+    if group_names is not None:
+        if groups is None:
+            raise ValueError(
+                "you provided group_names but not groups. "
+                "Please provide groups also."
+            )
+        if isiterable(group_names) and all(isinstance(s, str) for s in group_names):
+            group_names_ = np.array([set([s]) for s in group_names])
+        elif isiterable(group_names) and all(isiterable(s) for s in group_names):
+            group_names_ = np.array([set(s) for s in group_names])
+        else:
+            raise TypeError(
+                "group_names must be a sequence of strings or a sequence "
+                "of sequences. got {0} instead".format(group_names)
+            )
+        if len(group_names) != len(groups):
+            raise ValueError("group_names must have the same length as groups.")
+    else:
+        group_names_ = None
+
+    return group_names_
+
+
+def _check_group_subselection(selection, group_names_, var_name):
+    missing_grp_names_msg = f"if {var_name} is a string, you must provide group_names"
+    if selection is None:
+        selection_ = selection
+    elif isiterable(selection) and all(isinstance(e, int) for e in selection):
+        selection_ = np.array(selection)
+    elif isinstance(selection, int):
+        selection_ = np.array([selection])
+    elif isinstance(selection, str):
+        if group_names_ is None:
+            raise ValueError(missing_grp_names_msg)
+        mask = np.array(set([selection]) <= group_names_, dtype=bool)
+        selection_ = np.where(mask)[0]
+    elif isiterable(selection) and all(isinstance(e, str) for e in selection):
+        if group_names_ is None:
+            raise ValueError(missing_grp_names_msg)
+
+        mask = np.zeros_like(group_names_, dtype=bool)
+        for label in selection:
+            mask = np.logical_or(mask, set([label]) <= group_names_)
+
+        selection_ = np.where(mask)[0]
+    else:
+        raise ValueError(
+            f"{var_name} must be an int, string or sequence of ints or "
+            f"strings; got {selection} instead."
+        )
+
+    return selection_
+
+
 class GroupExtractor(BaseEstimator, TransformerMixin):
     """An sklearn-compatible group extractor.
 
@@ -26,8 +81,12 @@ class GroupExtractor(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    extract : numpy.ndarray or int, optional
+    extract : numpy.ndarray, int, or str, optional
         subsequence of desired groups to extract from feature matrix
+        If int or sequence of ints, these will be treated as group indices.
+        If str or sequence of str, these will be treated as labels for any
+        level of the (potentially multi-indexed) group names, which must be
+        specified in ``group_names``
 
     groups : list of numpy.ndarray
         list of arrays of non-overlapping indices for each group. For
@@ -37,13 +96,21 @@ class GroupExtractor(BaseEstimator, TransformerMixin):
         intercept feature, do not include it as a group. If None, all
         features will belong to one group.
 
+    group_names : sequence of str or sequences, optional
+        The names of the groups of X. If this is a sequence of strings, then
+        this transformer will extract groups whose names match ``extract``. If
+        this is a sequence of sequences, then this transformer will extract
+        groups that have labels that match ``extract`` at any level of their
+        multi-index.
+
     copy_X : bool, default=False
         if ``True``, X will be copied; else, ``transform`` may return a view
     """
 
-    def __init__(self, extract=None, groups=None, copy_X=False):
+    def __init__(self, extract=None, groups=None, group_names=None, copy_X=False):
         self.extract = extract
         self.groups = groups
+        self.group_names = group_names
         self.copy_X = copy_X
 
     def transform(self, X, y=None):
@@ -61,19 +128,10 @@ class GroupExtractor(BaseEstimator, TransformerMixin):
             force_all_finite=False,
         )
         groups = check_groups(groups=self.groups_, X=X, allow_overlap=True)
-        if self.extract is None:
+        if self.extract_ is None:
             return X
-        elif isiterable(self.extract) and all(isinstance(e, int) for e in self.extract):
-            extract = np.array(self.extract)
-        elif isinstance(self.extract, int):
-            extract = np.array([self.extract])
-        else:
-            raise ValueError(
-                "extract must be an int or sequence of ints; got "
-                "{0} instead".format(self.extract)
-            )
 
-        idx = np.concatenate([groups[e] for e in extract])
+        idx = np.concatenate([groups[e] for e in self.extract_])
         return X[:, idx]
 
     def fit(self, X=None, y=None):
@@ -87,6 +145,11 @@ class GroupExtractor(BaseEstimator, TransformerMixin):
 
         _, self.n_features_in_ = X.shape
         self.groups_ = check_groups(groups=self.groups, X=X, allow_overlap=True)
+        self.group_names_ = _check_group_names(self.groups, self.group_names)
+        self.extract_ = _check_group_subselection(
+            self.extract, self.group_names_, "extract"
+        )
+
         return self
 
     def _more_tags(self):  # pylint: disable=no-self-use
@@ -102,8 +165,12 @@ class GroupRemover(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    remove : numpy.ndarray or int, optional
+    remove : numpy.ndarray, int, or str, optional
         subsequence of desired groups to remove from feature matrix
+        If int or sequence of ints, these will be treated as group indices.
+        If str or sequence of str, these will be treated as labels for any
+        level of the (potentially multi-indexed) group names, which must be
+        specified in ``group_names``
 
     groups : list of numpy.ndarray
         list of arrays of non-overlapping indices for each group. For
@@ -113,13 +180,21 @@ class GroupRemover(BaseEstimator, TransformerMixin):
         intercept feature, do not include it as a group. If None, all
         features will belong to one group.
 
+    group_names : sequence of str or sequences, optional
+        The names of the groups of X. If this is a sequence of strings, then
+        this transformer will remove groups whose names match ``remove``. If
+        this is a sequence of sequences, then this transformer will remove
+        groups that have labels that match ``remove`` at any level of their
+        multi-index.
+
     copy_X : bool, default=False
         if ``True``, X will be copied; else, ``transform`` may return a view
     """
 
-    def __init__(self, remove=None, groups=None, copy_X=False):
+    def __init__(self, remove=None, groups=None, group_names=None, copy_X=False):
         self.remove = remove
         self.groups = groups
+        self.group_names = group_names
         self.copy_X = copy_X
 
     def transform(self, X, y=None):
@@ -137,20 +212,11 @@ class GroupRemover(BaseEstimator, TransformerMixin):
             force_all_finite=False,
         )
         groups = check_groups(groups=self.groups_, X=X, allow_overlap=True)
-        if self.remove is None:
+        if self.remove_ is None:
             return X
-        elif isiterable(self.remove) and all(isinstance(e, int) for e in self.remove):
-            remove = np.array(self.remove)
-        elif isinstance(self.remove, int):
-            remove = np.array([self.remove])
-        else:
-            raise ValueError(
-                "remove must be an int or sequence of ints; got "
-                "{0} instead".format(self.remove)
-            )
 
         idx = np.concatenate(
-            [grp for idx, grp in enumerate(groups) if idx not in remove]
+            [grp for idx, grp in enumerate(groups) if idx not in self.remove_]
         )
         return X[:, idx]
 
@@ -165,6 +231,11 @@ class GroupRemover(BaseEstimator, TransformerMixin):
 
         _, self.n_features_in_ = X.shape
         self.groups_ = check_groups(groups=self.groups, X=X, allow_overlap=True)
+        self.group_names_ = _check_group_names(self.groups, self.group_names)
+        self.remove_ = _check_group_subselection(
+            self.remove, self.group_names_, "remove"
+        )
+
         return self
 
     def _more_tags(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
Resolves #50 

WIP until I add all of the transformers.

Also, these transformers currently take indices of groups to extract/remove. We should optionally allow the user to pass a feature name to select or remove. We could then check the feature name against elements of the feature column names (provided as another kwarg or taken from `DataFrame.columns` if `X` is a dataframe). That way, the user wouldn't have to remember which group index corresponds to the CST, for example.