### PR TITLE
Add get_feature_names to transformers and PCA classes

### DIFF
--- a/groupyr/decomposition.py
+++ b/groupyr/decomposition.py
@@ -26,7 +26,7 @@ class _PCAFeatureNameMixin(_FeatureNameMixin):
         self.feature_names_out_ = []
         for idx, (grp, pca_model) in enumerate(zip(self.groups_out_, pca_models)):
             if self.group_names is None:
-                group_name = f"group{idx}"
+                group_name = "group" + str(idx).zfill(int(np.log10(len(self.groups_out_))+1)         
             else:
                 group_name = _stringify_sequence(self.group_names[idx])
             feature_type = "feature" if pca_model is None else "pc"

--- a/groupyr/decomposition.py
+++ b/groupyr/decomposition.py
@@ -26,7 +26,9 @@ class _PCAFeatureNameMixin(_FeatureNameMixin):
         self.feature_names_out_ = []
         for idx, (grp, pca_model) in enumerate(zip(self.groups_out_, pca_models)):
             if self.group_names is None:
-                group_name = "group" + str(idx).zfill(int(np.log10(len(self.groups_out_))+1)         
+                group_name = "group" + str(idx).zfill(
+                    int(np.log10(len(self.groups_out_)) + 1)
+                )
             else:
                 group_name = _stringify_sequence(self.group_names[idx])
             feature_type = "feature" if pca_model is None else "pc"

--- a/groupyr/tests/test_transform.py
+++ b/groupyr/tests/test_transform.py
@@ -326,6 +326,8 @@ def test_GroupAggregator():
     assert ga.feature_names_out_ == feature_names_ref  # nosec
     assert np.allclose(X_tr, X_ref)  # nosec
 
+    assert ga.get_feature_names() == ga.feature_names_out_
+
 
 def test_GroupResampler():
     X = np.arange(100).reshape(5, 20)

--- a/groupyr/tests/test_utils.py
+++ b/groupyr/tests/test_utils.py
@@ -2,8 +2,26 @@ import numpy as np
 import pytest
 
 from groupyr.datasets import make_group_regression
-from groupyr.utils import check_groups
+from groupyr.utils import check_groups, _stringify_sequence
 from sklearn.utils._testing import assert_array_almost_equal
+
+
+@pytest.mark.parametrize(
+    "_input, reference",
+    [
+        ("string", "string"),
+        (["foo", "bar", "baz"], "foo_bar_baz"),
+        (("foo", "bar", 1), "foo_bar_1"),
+    ],
+)
+def test_stringify_sequence(_input, reference):
+    output = _stringify_sequence(_input)
+    assert output == reference  # nosec
+
+
+def test_stringify_sequence_error():
+    with pytest.raises(TypeError):
+        _stringify_sequence(0)
 
 
 def test_check_groups():

--- a/groupyr/transform.py
+++ b/groupyr/transform.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array, check_random_state, check_scalar
 from sklearn.utils import shuffle as util_shuffle
 
-from .utils import check_groups
+from .utils import check_groups, _FeatureNameMixin, _stringify_sequence
 
 logger = logging.getLogger(__name__)
 
@@ -421,7 +421,7 @@ class GroupShuffler(BaseEstimator, TransformerMixin):
         return {"allow_nan": True, "multilabel": True, "multioutput": True}
 
 
-class GroupAggregator(BaseEstimator, TransformerMixin):
+class GroupAggregator(BaseEstimator, TransformerMixin, _FeatureNameMixin):
     """Aggregate each group of a feature matrix using one or more functions.
 
     Parameters
@@ -549,7 +549,9 @@ class GroupAggregator(BaseEstimator, TransformerMixin):
         self.feature_names_out_ = []
         for grp_name in group_names_out:
             for fun in self.func_:
-                self.feature_names_out_.append("__".join([grp_name, fun.__name__]))
+                self.feature_names_out_.append(
+                    "__".join([_stringify_sequence(grp_name), fun.__name__])
+                )
 
         self.n_features_out_ = len(self.feature_names_out_)
 
@@ -564,7 +566,7 @@ def _resample_features(X, n_features_out, kind="linear"):
     return f(np.linspace(0, 1, n_features_out))
 
 
-class GroupResampler(BaseEstimator, TransformerMixin):
+class GroupResampler(BaseEstimator, TransformerMixin, _FeatureNameMixin):
     """Upsample or downsample each group.
 
     Parameters

--- a/groupyr/utils.py
+++ b/groupyr/utils.py
@@ -1,6 +1,23 @@
 """Utility functions for SGL-based estimators."""
 import numpy as np
 
+from collections.abc import Sequence
+
+
+def _stringify_sequence(sequence):
+    if isinstance(sequence, str):
+        return sequence
+    elif isinstance(sequence, Sequence):
+        return "_".join([str(el) for el in sequence])
+    else:
+        raise TypeError("group_name must be a string or sequence.")
+
+
+class _FeatureNameMixin:
+    def get_feature_names(self):
+        """Return a list of feature names."""
+        return self.feature_names_out_
+
 
 def check_groups(groups, X, allow_overlap=False, fit_intercept=False, kwarg_name="X"):
     """Validate group indices.


### PR DESCRIPTION
Resolves #63

This PR adds a `get_feature_names` method to most of the transformers and the PCA classes.