### PR TITLE
Change the key name to only have one underscore.

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         run: |
           flake8
-          black --check .
+          black --check . --exclude groupyr/_version.py
           pydocstyle
       - name: Test
         run: |

--- a/groupyr/logistic.py
+++ b/groupyr/logistic.py
@@ -1138,7 +1138,7 @@ class LogisticSGLCV(LogisticSGL):
             self.n_iter_ = self.bayes_optimizer_.best_estimator_.n_iter_
             self.is_fitted_ = True
             self.scoring_path_ = None
-            param_alpha = self.bayes_optimizer_.cv_results_["param__alpha"]
+            param_alpha = self.bayes_optimizer_.cv_results_["param_alpha"]
             self.alphas_ = np.sort(param_alpha)[::-1]
 
         return self

--- a/groupyr/sgl.py
+++ b/groupyr/sgl.py
@@ -1197,7 +1197,7 @@ class SGLCV(LinearModel, RegressorMixin, TransformerMixin):
             self.n_iter_ = self.bayes_optimizer_.best_estimator_.n_iter_
             self.is_fitted_ = True
             self.scoring_path_ = None
-            param_alpha = self.bayes_optimizer_.cv_results_["param__alpha"]
+            param_alpha = self.bayes_optimizer_.cv_results_["param_alpha"]
             self.alphas_ = np.sort(param_alpha)[::-1]
 
         return self

--- a/groupyr/tests/test_sgl.py
+++ b/groupyr/tests/test_sgl.py
@@ -179,6 +179,7 @@ def test_sgl_cv(tuning_strategy):
         ).fit(X, y)
         assert clf.score(X_test, y_test) > 0.98  # nosec
         assert_almost_equal(clf.alpha_, 0.06, 2)
+        assert len(clf.alphas_) == 20
 
 
 @pytest.mark.parametrize("execution_number", range(5))
@@ -269,5 +270,6 @@ def test_LogisticSGLCV_BayesSearchCV():
     gs = BayesSearchCV(clf, search_spaces, cv=cv, random_state=42, n_iter=10)
     gs.fit(X, y)
 
+    assert len(clf_cv.alphas_) == 10
     assert gs.best_params_["l1_ratio"] == clf_cv.l1_ratio_
     assert gs.best_params_["alpha"] == clf_cv.alpha_


### PR DESCRIPTION
Potentially closes #65.

I noticed that `param__alpha` is also used [here](https://github.com/richford/groupyr/blob/main/groupyr/logistic.py#L1141) (in "logistic.py"). Do we need to change it there as well? Also, any suggestions for testing?