### PR TITLE
Limit verbatim quotation in documentation of sample generators

### DIFF
--- a/groupyr/datasets.py
+++ b/groupyr/datasets.py
@@ -30,13 +30,9 @@ def make_group_classification(
 ):
     """Generate a random n-class sparse group classification problem.
 
-    This initially creates clusters of points normally distributed (std=1)
-    about vertices of an ``n_informative``-dimensional hypercube with sides of
-    length ``2*class_sep`` and assigns an equal number of clusters to each
-    class. It introduces interdependence between these features and adds
-    various types of further noise to the data.
-
-    Prior to shuffling, ``X`` stacks a number of these primary "informative"
+    This function is a generalization of sklearn.datasets.make_classification
+    to feature matrices with grouped covariates. Prior to shuffling, ``X`` 
+    stacks a number of these primary "informative"
     features, "redundant" linear combinations of these, "repeated" duplicates
     of sampled features, and arbitrary noise for and remaining features.
     This method uses sklearn.datasets.make_classification to construct a
@@ -283,8 +279,10 @@ def make_group_regression(
     random_state=None,
 ):
     """Generate a sparse group regression problem.
-
-    Prior to shuffling, ``X`` stacks a number of these primary "informative"
+    
+    This function is a generalization of sklearn.datasets.make_regression
+    to feature matrices with grouped covariates. Prior to shuffling, ``X``
+    stacks a number of these primary "informative"
     features, and arbitrary noise for and remaining features.
     This method uses sklearn.datasets.make_regression to construct a
     giant unshuffled regression problem of size

--- a/groupyr/datasets.py
+++ b/groupyr/datasets.py
@@ -31,7 +31,7 @@ def make_group_classification(
     """Generate a random n-class sparse group classification problem.
 
     This function is a generalization of sklearn.datasets.make_classification
-    to feature matrices with grouped covariates. Prior to shuffling, ``X`` 
+    to feature matrices with grouped covariates. Prior to shuffling, ``X``
     stacks a number of these primary "informative"
     features, "redundant" linear combinations of these, "repeated" duplicates
     of sampled features, and arbitrary noise for and remaining features.
@@ -279,7 +279,7 @@ def make_group_regression(
     random_state=None,
 ):
     """Generate a sparse group regression problem.
-    
+
     This function is a generalization of sklearn.datasets.make_regression
     to feature matrices with grouped covariates. Prior to shuffling, ``X``
     stacks a number of these primary "informative"


### PR DESCRIPTION
Resolves #71 by limiting the verbatim quotation of sklearn's sample generators.