### PR TITLE
BF: Update joblib parallel args

### DIFF
--- a/groupyr/logistic.py
+++ b/groupyr/logistic.py
@@ -14,7 +14,6 @@ from sklearn.metrics import get_scorer
 from sklearn.model_selection import check_cv
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils.fixes import _joblib_parallel_args
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_array, check_is_fitted, column_or_1d
 
@@ -1027,7 +1026,7 @@ class LogisticSGLCV(LogisticSGL):
             score_paths = Parallel(
                 n_jobs=self.n_jobs,
                 verbose=parallel_verbosity,
-                **_joblib_parallel_args(prefer="threads"),
+                prefer="threads",
             )(jobs)
 
             coefs_paths, alphas_paths, scores, n_iters = zip(*score_paths)

--- a/groupyr/sgl.py
+++ b/groupyr/sgl.py
@@ -17,7 +17,6 @@ from sklearn.linear_model._coordinate_descent import _alpha_grid as _lasso_alpha
 from sklearn.metrics import get_scorer
 from sklearn.model_selection import check_cv
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils.fixes import _joblib_parallel_args
 from sklearn.utils.validation import check_array, check_is_fitted, column_or_1d
 
 from ._base import SGLBaseEstimator
@@ -1095,7 +1094,7 @@ class SGLCV(LinearModel, RegressorMixin, TransformerMixin):
             score_paths = Parallel(
                 n_jobs=self.n_jobs,
                 verbose=parallel_verbosity,
-                **_joblib_parallel_args(prefer="threads"),
+                prefer="threads",
             )(jobs)
 
             coefs_paths, alphas_paths, scores, n_iters = zip(*score_paths)


### PR DESCRIPTION
This PR fixes an import error in newer versions of sklearn but removing the `_joblib_parallel_args` functions and passing `prefer` directly to `joblib.Parallel`.