### PR TITLE
Don't pin the numpy version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ setup_requires =
 python_requires = >=3.10
 install_requires =
     copt==0.9.1
-    numpy>=1.21.5
     scikit-learn>=1.0.0
     scipy
     scikit-optimize==0.9.0


### PR DESCRIPTION
This complicates the installation of AFQ-Insight, and hardly seems necessary. 